### PR TITLE
Working components.livemd

### DIFF
--- a/guides/components.livemd
+++ b/guides/components.livemd
@@ -2,7 +2,7 @@
 
 ```elixir
 Mix.install([
-  {:kino_benchee, "~> 0.1.0"}
+  {:kino_benchee,  github: "livebook-dev/kino_benchee"}
 ])
 ```
 


### PR DESCRIPTION
As :kino_benchee hasn't been published to hex, it's necessary to pull the dependency directly from github when running in Livebook. This is a trivial change but improves the experience for first time users as they don't have to figure out what's wrong with the install stanza.