### PR TITLE
Use multi-facet charts with multiple inputs

### DIFF
--- a/lib/kino_benchee.ex
+++ b/lib/kino_benchee.ex
@@ -25,12 +25,57 @@ defimpl Kino.Render, for: Benchee.Suite do
     Kino.Render.to_livebook(tabs)
   end
 
+  defp chart(
+         %{configuration: %{input_names: input_names}} = suite_results,
+         title,
+         field,
+         field_title
+       )
+       when input_names != [] do
+    VegaLite.new(title: title)
+    |> VegaLite.data_from_values(suite_results,
+      only: ["job_name", "input_name", field]
+    )
+    |> VegaLite.facet(
+      [
+        row: [
+          field: "input_name",
+          title: nil,
+          sort: suite_results.configuration.input_names,
+          header: [
+            label_orient: "top",
+            label_font_style: "italic",
+            label_font_size: 16
+          ]
+        ]
+      ],
+      VegaLite.new(width: 600, height: 400)
+      |> VegaLite.mark(:bar)
+      |> VegaLite.encode_field(:y, "job_name", type: :nominal, title: "Job name")
+      |> VegaLite.encode_field(:x, field,
+        type: :quantitative,
+        title: field_title
+      )
+      |> VegaLite.encode_field(:color, "job_name", type: :nominal, title: "Job name")
+    )
+  end
+
+  defp chart(suite_results, title, field, field_title) do
+    VegaLite.new(width: 600, height: 400, title: title)
+    |> VegaLite.data_from_values(suite_results, only: ["job_name", field])
+    |> VegaLite.mark(:bar)
+    |> VegaLite.encode_field(:y, "job_name", type: :nominal, title: "Job name")
+    |> VegaLite.encode_field(:x, field, type: :quantitative, title: field_title)
+    |> VegaLite.encode_field(:color, "job_name", type: :nominal, title: "Job name")
+  end
+
   defp memory_table(suite_results) do
     Kino.DataTable.new(
       suite_results,
       name: "Memory Usage Comparison",
       keys: [
         "job_name",
+        "input_name",
         "memory_average",
         "memory_minimum",
         "memory_maximum",
@@ -40,19 +85,12 @@ defimpl Kino.Render, for: Benchee.Suite do
   end
 
   defp memory_chart(suite_results) do
-    VegaLite.new(
-      width: 600,
-      height: 400,
-      title: "Average Memory Usage (lower is better)"
+    chart(
+      suite_results,
+      "Average Memory Usage (lower is better)",
+      "memory_average",
+      "Memory usage (bytes)"
     )
-    |> VegaLite.data_from_values(suite_results, only: ["job_name", "memory_average"])
-    |> VegaLite.mark(:bar)
-    |> VegaLite.encode_field(:y, "job_name", type: :nominal, title: "Job name")
-    |> VegaLite.encode_field(:x, "memory_average",
-      type: :quantitative,
-      title: "Memory usage (bytes)"
-    )
-    |> VegaLite.encode_field(:color, "job_name", type: :nominal)
   end
 
   defp run_time_table(suite_results) do
@@ -61,6 +99,7 @@ defimpl Kino.Render, for: Benchee.Suite do
       name: "Run Time Comparison",
       keys: [
         "job_name",
+        "input_name",
         "run_time_ips",
         "run_time_average",
         "run_time_minimum",
@@ -71,19 +110,12 @@ defimpl Kino.Render, for: Benchee.Suite do
   end
 
   defp run_time_chart(suite_results) do
-    VegaLite.new(
-      width: 600,
-      height: 400,
-      title: "Average Iterations per Second (higher is better)"
+    chart(
+      suite_results,
+      "Average Iterations per Second (higher is better)",
+      "run_time_ips",
+      "Iterations per second"
     )
-    |> VegaLite.data_from_values(suite_results, only: ["job_name", "run_time_ips"])
-    |> VegaLite.mark(:bar)
-    |> VegaLite.encode_field(:y, "job_name", type: :nominal, title: "Job name")
-    |> VegaLite.encode_field(:x, "run_time_ips",
-      type: :quantitative,
-      title: "Iterations per second"
-    )
-    |> VegaLite.encode_field(:color, "job_name", type: :nominal)
   end
 
   defp reductions_table(suite_results) do
@@ -92,6 +124,7 @@ defimpl Kino.Render, for: Benchee.Suite do
       name: "Reductions Comparison",
       keys: [
         "job_name",
+        "input_name",
         "reductions_average",
         "reductions_minimum",
         "reductions_maximum",
@@ -101,14 +134,11 @@ defimpl Kino.Render, for: Benchee.Suite do
   end
 
   defp reductions_chart(suite_results) do
-    VegaLite.new(width: 600, height: 400, title: "Average Reductions (lower is better)")
-    |> VegaLite.data_from_values(suite_results, only: ["job_name", "reductions_average"])
-    |> VegaLite.mark(:bar)
-    |> VegaLite.encode_field(:y, "job_name", type: :nominal, title: "Job name")
-    |> VegaLite.encode_field(:x, "reductions_average",
-      type: :quantitative,
-      title: "Reductions count"
+    chart(
+      suite_results,
+      "Average Reductions (lower is better)",
+      "reductions_average",
+      "Reductions count"
     )
-    |> VegaLite.encode_field(:color, "job_name", type: :nominal)
   end
 end


### PR DESCRIPTION
Displaying Benchee benchmarks with multiple inputs get combined into one chart output which makes the result unclear.

Instead, display these as different facets

Depends on https://github.com/bencheeorg/benchee/pull/476 in Benchee to expose `input_name` in `Table.Reader` to get the input name to facet on.

**Example with no inputs (same as current behavior)**
<img width="800" height="476" alt="visualization" src="https://github.com/user-attachments/assets/7ed826d3-ffc1-4f4a-a870-b2b274245257" />

**Example with inputs**
<img width="802" height="1394" alt="visualization (1)" src="https://github.com/user-attachments/assets/7c4e1a91-b87a-42d7-8efb-8e47e10b8349" />

Example LiveBook with examples: https://gist.github.com/madlep/e47e183b535e9213e53ec99eba6c9dcd